### PR TITLE
Fix for Makefile on case-insensitive filesystems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,4 @@ install:
 	python setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
 
 .PHONY : doc
+.PHONY : install


### PR DESCRIPTION
Explicitly declared the install target as PHONY due to issues on case-insensitive filesystems with the INSTALL docs
