### PR TITLE
Issue #31 'make install' on OSX lion installs in wrong dir

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,3 +12,7 @@ Examples:
 
     * make install DESTDIR=~/ino
     * make install PREFIX=/usr
+
+For OSX user:
+    make install_osx
+

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ doc:
 install:
 	python setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
 
+install_osx:
+	python setup.py install
+
 .PHONY : doc
 .PHONY : install

--- a/ino/commands/serial.py
+++ b/ino/commands/serial.py
@@ -22,6 +22,8 @@ class Serial(Command):
                             help='Serial port to communicate with\nTry to guess if not specified')
         parser.add_argument('-b', '--baud-rate', metavar='RATE', type=int, default=9600, 
                             help='Communication baud rate, should match value set in Serial.begin() on Arduino')
+        parser.add_argument('-e', '--escape', metavar='ESCAPE', type=str, default='a', 
+                            help='Escape character to send commands to picocom itself.')
 
     def run(self, args):
         serial_monitor = self.e.find_tool('serial', ['picocom'], human_name='Serial monitor (picocom)')
@@ -31,5 +33,6 @@ class Serial(Command):
             serial_monitor,
             serial_port,
             '-b', str(args.baud_rate),
+            '-e', str(args.escape),
             '-l',
         ])


### PR DESCRIPTION
I'm installing ino by cloning the github repo and running 'make
install'. It appears to install the lib files at
'/usr/local/lib/python2.7/site-packages/ino'. When I run:
ino build, I get:
Traceback (most recent call last):
File "/usr/local/bin/ino", line 3, in <module>
from ino.runner import main
ImportError: No module named ino.runner

I believe the correct place to install would be
/Library/Python/2.7/site-packages/ino
If I'm in error please let me know the correct procedure to install on
OSX; I'm not terribly knowledgable of python.

running 'python setup.py' with no CL flags seems to install in the
proper place. I'm not sure what the best solution is so I just
create a new make task
