### PR TITLE
Overhauled handling of compiler flags. Closes #8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 ino.egg-info
 doc/.build
+.*.sw[op]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ doc:
 	$(MAKE) -f doc/Makefile html
 
 install:
-	python setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
+	env python2 setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
 
 .PHONY : doc
 .PHONY : install

--- a/TODO
+++ b/TODO
@@ -1,0 +1,11 @@
+# ino TODO list:
+
+- Make 'ino build' sensitive to changes all kinds of changes to arguments, so
+  that whenever, for instance, '--cppflags' changes, the code is
+  _automatically_ recompiled with the new options (rather than having to
+  manually invoke 'ino clean' as currently)
+- For completeness, add --arflags and --objcopyflags in build.py
+  * Also create similar flags for all modules, so every program used by ino can
+    be specified (e.g. for 'ino serial')
+
+<!-- vim: set ft=markdown: -->

--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -44,6 +44,10 @@ class Build(Command):
         super(Build, self).setup_arg_parser(parser)
         self.e.add_board_model_arg(parser)
         self.e.add_arduino_dist_arg(parser)
+        self.e.add_cc_arg(parser)
+        self.e.add_cxx_arg(parser)
+        self.e.add_ar_arg(parser)
+        self.e.add_objcopy_arg(parser)
         self.e.add_cppflags_arg(parser)
         self.e.add_cflags_arg(parser)
         self.e.add_cxxflags_arg(parser)
@@ -51,7 +55,7 @@ class Build(Command):
         parser.add_argument('-v', '--verbose', default=False, action='store_true',
                             help='Verbose make output')
 
-    def discover(self):
+    def discover(self, args):
         self.e.find_arduino_dir('arduino_core_dir', 
                                 ['hardware', 'arduino', 'cores', 'arduino'], 
                                 ['Arduino.h'] if self.e.arduino_lib_version.major else ['WProgram.h'], 
@@ -66,10 +70,10 @@ class Build(Command):
                                     human_name='Arduino variants directory')
 
         toolset = [
-            ('cc', 'avr-gcc'),
-            ('cxx', 'avr-g++'),
-            ('ar', 'avr-ar'),
-            ('objcopy', 'avr-objcopy'),
+            ('cc', args.cc),
+            ('cxx', args.cxx),
+            ('ar', args.ar),
+            ('objcopy', args.objcopy),
         ]
 
         for tool_key, tool_binary in toolset:
@@ -211,7 +215,7 @@ class Build(Command):
         self.e['cppflags'].extend(self.recursive_inc_lib_flags(used_libs))
 
     def run(self, args):
-        self.discover()
+        self.discover(args)
         self.setup_flags(args)
         self.create_jinja(verbose=args.verbose)
         self.make('Makefile.sketch')

--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -40,18 +40,70 @@ class Build(Command):
     name = 'build'
     help_line = "Build firmware from the current directory project"
 
+    default_cc = 'avr-gcc'
+    default_cxx = 'avr-g++'
+    default_ar = 'avr-ar'
+    default_objcopy = 'avr-objcopy'
+
+    default_cppflags = '-ffunction-sections -fdata-sections -g -Os -w'
+    default_cflags = ''
+    default_cxxflags = '-fno-exceptions'
+    default_ldflags = '-Os --gc-sections'
+
     def setup_arg_parser(self, parser):
         super(Build, self).setup_arg_parser(parser)
         self.e.add_board_model_arg(parser)
         self.e.add_arduino_dist_arg(parser)
-        self.e.add_cc_arg(parser)
-        self.e.add_cxx_arg(parser)
-        self.e.add_ar_arg(parser)
-        self.e.add_objcopy_arg(parser)
-        self.e.add_cppflags_arg(parser)
-        self.e.add_cflags_arg(parser)
-        self.e.add_cxxflags_arg(parser)
-        self.e.add_ldflags_arg(parser)
+
+        parser.add_argument('-c', '--cc', metavar='COMPILER',
+                            default=self.default_cc,
+                            help='Specifies the compiler used for C files. If '
+                            'a full path is not given, searches in Arduino '
+                            'directories _before_ PATH. Default: %(default)s.')
+        parser.add_argument('-+', '--cxx', metavar='COMPILER',
+                            default=self.default_cxx,
+                            help='Specifies the compiler used for C++ files. '
+                            'If a full path is not given, searches in Arduino '
+                            'directories _before_ PATH. Default: %(default)s.')
+        parser.add_argument('-a', '--ar', metavar='AR',
+                            default=self.default_ar,
+                            help='Specifies the AR tool to use. If a full path '
+                            'is not given, searches in Arduino directories '
+                            'before PATH. Default: %(default)s.')
+        parser.add_argument('-o', '--objcopy', metavar='OBJCOPY',
+                            default=self.default_objcopy,
+                            help='Specifies the OBJCOPY to use. If a full path '
+                            'is not given, searches in Arduino directories '
+                            'before PATH. Default: %(default)s.')
+
+        parser.add_argument('-p', '--cppflags', metavar='FLAGS',
+                            default=self.default_cppflags,
+                            help='Flags that will be passed to the compiler. '
+                            'Note that multiple (space-separated) flags must '
+                            'be surrounded by quotes, e.g. '
+                            '`--cflags="-DC1 -DC2"\' specifies flags to define '
+                            'the constants C1 and C2. Default: %(default)s')
+
+        parser.add_argument('-f', '--cflags', metavar='FLAGS',
+                            default=self.default_cflags,
+                            help='Like --cppflags, but the flags specified are '
+                            'only passed to compilations of C source files. '
+                            'Default: %(default)s')
+
+        parser.add_argument('-x', '--cxxflags', metavar='FLAGS',
+                            default=self.default_cxxflags,
+                            help='Like --cppflags, but the flags specified '
+                            'are only passed to compilations of C++ source '
+                            'files. Default: %(default)s')
+
+        parser.add_argument('-l', '--ldflags', metavar='FLAGS',
+                            default=self.default_ldflags,
+                            help='Like --cppflags, but the flags specified '
+                            'are only passed during the linking stage. Note '
+                            'these flags should be specified as if `ld\' were '
+                            'being invoked directly (i.e. the `-Wl,\' prefix '
+                            'should be omitted). Default: %(default)s')
+
         parser.add_argument('-v', '--verbose', default=False, action='store_true',
                             help='Verbose make output')
 

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -67,6 +67,11 @@ class Environment(dict):
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
 
+    default_cppflags = '-ffunction-sections -fdata-sections -g -Os -w'
+    default_cflags = ''
+    default_cxxflags = '-fno-exceptions'
+    default_ldflags = '-Os --gc-sections'
+
     default_board_model = 'uno'
     ino = sys.argv[0]
 
@@ -210,6 +215,48 @@ class Environment(dict):
     def add_arduino_dist_arg(self, parser):
         parser.add_argument('-d', '--arduino-dist', metavar='PATH', 
                             help='Path to Arduino distribution, e.g. ~/Downloads/arduino-0022.\nTry to guess if not specified')
+
+    def add_cppflags_arg(self, parser):
+        help = '\n'.join([
+            'Flags that will be passed to the compiler.',
+            'Note that multiple (space-separated) flags',
+            'must be surrounded by quotes, e.g.',
+            '`--cflags="-DC1 -DC2"\' specifies flags to',
+            'define the constants C1 and C2. Default:',
+            '%(default)s',
+        ])
+        parser.add_argument('-p', '--cppflags', metavar='FLAGS',
+                            default=self.default_cppflags, help=help)
+
+    def add_cflags_arg(self, parser):
+        help = '\n'.join([
+            'Like --cppflags, but the flags specified',
+            'are only passed to compilations of C source',
+            'files. Default: %(default)s',
+        ])
+        parser.add_argument('-c', '--cflags', metavar='FLAGS',
+                            default=self.default_cflags, help=help)
+
+    def add_cxxflags_arg(self, parser):
+        help = '\n'.join([
+            'Like --cppflags, but the flags specified',
+            'are only passed to compilations of C++ source',
+            'files. Default: %(default)s',
+        ])
+        parser.add_argument('-x', '--cxxflags', metavar='FLAGS',
+                            default=self.default_cxxflags, help=help)
+
+    def add_ldflags_arg(self, parser):
+        help = '\n'.join([
+            'Like --cppflags, but the flags specified',
+            'are only passed during the linking stage.',
+            'Note these flags should be specified as if',
+            '`ld\' were being invoked directly (i.e. the',
+            '`-Wl,\' prefix should be omitted). Default:',
+            '%(default)s',
+        ])
+        parser.add_argument('-l', '--ldflags', metavar='FLAGS',
+                            default=self.default_ldflags, help=help)
 
     def serial_port_patterns(self):
         system = platform.system()

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -67,16 +67,6 @@ class Environment(dict):
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
 
-    default_cc = 'avr-gcc'
-    default_cxx = 'avr-g++'
-    default_ar = 'avr-ar'
-    default_objcopy = 'avr-objcopy'
-
-    default_cppflags = '-ffunction-sections -fdata-sections -g -Os -w'
-    default_cflags = ''
-    default_cxxflags = '-fno-exceptions'
-    default_ldflags = '-Os --gc-sections'
-
     default_board_model = 'uno'
     ino = sys.argv[0]
 
@@ -220,87 +210,6 @@ class Environment(dict):
     def add_arduino_dist_arg(self, parser):
         parser.add_argument('-d', '--arduino-dist', metavar='PATH', 
                             help='Path to Arduino distribution, e.g. ~/Downloads/arduino-0022.\nTry to guess if not specified')
-
-    def add_cc_arg(self, parser):
-        help = '\n'.join([
-            'Specifies the compiler used for C files.',
-            'If a full path is not given, searches in',
-            'Arduino directories before PATH. Default:',
-            '%(default)s.'
-        ])
-        parser.add_argument('-c', '--cc', metavar='COMPILER',
-                            default=self.default_cc, help=help)
-
-    def add_cxx_arg(self, parser):
-        help = '\n'.join([
-            'Specifies the compiler used for C++ files.',
-            'If a full path is not given, searches in',
-            'Arduino directories before PATH. Default:',
-            '%(default)s.'
-        ])
-        parser.add_argument('-+', '--cxx', metavar='COMPILER',
-                            default=self.default_cxx, help=help)
-
-    def add_ar_arg(self, parser):
-        help = '\n'.join([
-            'Specifies the AR tool to use. If a full',
-            'path is not given, searches in Arduino',
-            'directories before PATH. Default: %(default)s.'
-        ])
-        parser.add_argument('-a', '--ar', metavar='AR',
-                            default=self.default_ar, help=help)
-
-    def add_objcopy_arg(self, parser):
-        help = '\n'.join([
-            'Specifies the OBJCOPY to use. If a full',
-            'path is not given, searches in Arduino',
-            'directories before PATH. Default: %(default)s.'
-        ])
-        parser.add_argument('-o', '--objcopy', metavar='OBJCOPY',
-                            default=self.default_objcopy, help=help)
-
-
-    def add_cppflags_arg(self, parser):
-        help = '\n'.join([
-            'Flags that will be passed to the compiler.',
-            'Note that multiple (space-separated) flags',
-            'must be surrounded by quotes, e.g.',
-            '`--cflags="-DC1 -DC2"\' specifies flags to',
-            'define the constants C1 and C2. Default:',
-            '%(default)s',
-        ])
-        parser.add_argument('-p', '--cppflags', metavar='FLAGS',
-                            default=self.default_cppflags, help=help)
-
-    def add_cflags_arg(self, parser):
-        help = '\n'.join([
-            'Like --cppflags, but the flags specified',
-            'are only passed to compilations of C source',
-            'files. Default: %(default)s',
-        ])
-        parser.add_argument('-f', '--cflags', metavar='FLAGS',
-                            default=self.default_cflags, help=help)
-
-    def add_cxxflags_arg(self, parser):
-        help = '\n'.join([
-            'Like --cppflags, but the flags specified',
-            'are only passed to compilations of C++ source',
-            'files. Default: %(default)s',
-        ])
-        parser.add_argument('-x', '--cxxflags', metavar='FLAGS',
-                            default=self.default_cxxflags, help=help)
-
-    def add_ldflags_arg(self, parser):
-        help = '\n'.join([
-            'Like --cppflags, but the flags specified',
-            'are only passed during the linking stage.',
-            'Note these flags should be specified as if',
-            '`ld\' were being invoked directly (i.e. the',
-            '`-Wl,\' prefix should be omitted). Default:',
-            '%(default)s',
-        ])
-        parser.add_argument('-l', '--ldflags', metavar='FLAGS',
-                            default=self.default_ldflags, help=help)
 
     def serial_port_patterns(self):
         system = platform.system()

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -67,6 +67,11 @@ class Environment(dict):
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
 
+    default_cc = 'avr-gcc'
+    default_cxx = 'avr-g++'
+    default_ar = 'avr-ar'
+    default_objcopy = 'avr-objcopy'
+
     default_cppflags = '-ffunction-sections -fdata-sections -g -Os -w'
     default_cflags = ''
     default_cxxflags = '-fno-exceptions'
@@ -216,6 +221,45 @@ class Environment(dict):
         parser.add_argument('-d', '--arduino-dist', metavar='PATH', 
                             help='Path to Arduino distribution, e.g. ~/Downloads/arduino-0022.\nTry to guess if not specified')
 
+    def add_cc_arg(self, parser):
+        help = '\n'.join([
+            'Specifies the compiler used for C files.',
+            'If a full path is not given, searches in',
+            'Arduino directories before PATH. Default:',
+            '%(default)s.'
+        ])
+        parser.add_argument('-c', '--cc', metavar='COMPILER',
+                            default=self.default_cc, help=help)
+
+    def add_cxx_arg(self, parser):
+        help = '\n'.join([
+            'Specifies the compiler used for C++ files.',
+            'If a full path is not given, searches in',
+            'Arduino directories before PATH. Default:',
+            '%(default)s.'
+        ])
+        parser.add_argument('-+', '--cxx', metavar='COMPILER',
+                            default=self.default_cxx, help=help)
+
+    def add_ar_arg(self, parser):
+        help = '\n'.join([
+            'Specifies the AR tool to use. If a full',
+            'path is not given, searches in Arduino',
+            'directories before PATH. Default: %(default)s.'
+        ])
+        parser.add_argument('-a', '--ar', metavar='AR',
+                            default=self.default_ar, help=help)
+
+    def add_objcopy_arg(self, parser):
+        help = '\n'.join([
+            'Specifies the OBJCOPY to use. If a full',
+            'path is not given, searches in Arduino',
+            'directories before PATH. Default: %(default)s.'
+        ])
+        parser.add_argument('-o', '--objcopy', metavar='OBJCOPY',
+                            default=self.default_objcopy, help=help)
+
+
     def add_cppflags_arg(self, parser):
         help = '\n'.join([
             'Flags that will be passed to the compiler.',
@@ -234,7 +278,7 @@ class Environment(dict):
             'are only passed to compilations of C source',
             'files. Default: %(default)s',
         ])
-        parser.add_argument('-c', '--cflags', metavar='FLAGS',
+        parser.add_argument('-f', '--cflags', metavar='FLAGS',
                             default=self.default_cflags, help=help)
 
     def add_cxxflags_arg(self, parser):

--- a/ino/make/Makefile.deps.jinja
+++ b/ino/make/Makefile.deps.jinja
@@ -29,7 +29,7 @@
 {{ output_filepath }} : {{ cpp.target_paths() }}
 	@echo {{ ('Scanning dependencies of ' ~ src_dir|basename)|colorize('cyan') }}
 	@mkdir -p {{ output_filepath|dirname }}
-	{{v}}cat $^ > $@;
+	{{v}}{{ 'cat $^ >' if cpp.target_paths() else 'touch' }} $@;
 
 all : {{ output_filepath }}
 	@true

--- a/ino/make/Makefile.deps.jinja
+++ b/ino/make/Makefile.deps.jinja
@@ -16,7 +16,7 @@
 {% for source, target in cpp.items() %}
 {{ target.path }} : {{ source.path }}
 	@mkdir -p {{ target.path|dirname }}
-	{{v}}{{ e.cc }} {{ e.cflags }} {{ inc_flags }} {{ iquote(source) }} -MM $^ > $@
+	{{v}}{{ e.cc }} {{ e.cppflags }} {{ inc_flags }} {{ iquote(source) }} -MM $^ > $@
 	{# prepend build path to a target in the generated file and 
 	   add .d file itself as a target so that changes in a header file would rebuild dependency files
 	   See: http://make.paulandlesley.org/autodep.html #}

--- a/ino/make/Makefile.jinja
+++ b/ino/make/Makefile.jinja
@@ -15,11 +15,11 @@ include {{ target.path|depsname }}
 {% endmacro %}
 
 {% macro compile_c(filemap) %}
-{{ compile(filemap, e.cc ~ ' ' ~ e.cflags) }}
+{{ compile(filemap, e.cc ~ ' ' ~ e.cppflags ~ ' ' ~ e.cflags) }}
 {% endmacro %}
 
 {% macro compile_cpp(filemap) %}
-{{ compile(filemap, e.cxx ~ ' ' ~ e.cflags ~ ' ' ~ e.cxxflags) }}
+{{ compile(filemap, e.cxx ~ ' ' ~ e.cppflags ~ ' ' ~ e.cxxflags) }}
 {% endmacro %}
 
 {#
@@ -56,7 +56,7 @@ include {{ target.path|depsname }}
 {% set elf = e.build_dir|pjoin('firmware.elf') %}
 {{ elf }} : {{ objs }}
 	@echo {{ 'Linking firmware.elf'|colorize('green') }}
-	{{v}}{{ e.cc }} {{ e.elfflags }} -o $@ $^ -lm
+	{{v}}{{ e.cc }} {{ e.ldflags }} -o $@ $^ -lm
 
 {#
  #   elf -> hex


### PR DESCRIPTION
Previously all compiler flags (cxxflags etc) were hardcoded into `ino',
which is inflexible since, for instance, it is not even possible to
define constants (via `-D') on the command-line at compile time.  This
commit adds the `--cppflags', `--cflags', `--cxxflags' and `--ldflags'
command-line options in order to improve this situation.

In summary, all are documented under `ino build --help'; defaults are
preserved as before; and the user is not able to void any flags (e.g.
include paths for the required libraries) which are essential for the
building of a sketch
