### PR TITLE
Fixes avrdude.conf location problem in Fedora

### DIFF
--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -39,7 +39,10 @@ class Upload(Command):
         self.e.find_tool('stty', ['stty'])
         if platform.system() == 'Linux':
             self.e.find_arduino_tool('avrdude', ['hardware', 'tools'])
-            self.e.find_arduino_file('avrdude.conf', ['hardware', 'tools'])
+            if os.path.exists('/etc/avrdude/avrdude.conf'):
+              self.e['avrdude.conf'] = '/etc/avrdude/avrdude.conf'
+            else:
+              self.e.find_arduino_file('avrdude.conf', ['hardware', 'tools'])
         else:
             self.e.find_arduino_tool('avrdude', ['hardware', 'tools', 'avr', 'bin'])
             self.e.find_arduino_file('avrdude.conf', ['hardware', 'tools', 'avr', 'etc'])


### PR DESCRIPTION
Fedora packages avrdude so that the .conf file is in /etc/avrdude, see https://bugzilla.redhat.com/show_bug.cgi?id=985904

I have created this patch for the ino package in Fedora to make it work, would be nice to get it upstream.
