### PR TITLE
Solves problem with error '<enum|struct|typedef>' not declared in this scope.

### DIFF
--- a/ino/commands/preproc.py
+++ b/ino/commands/preproc.py
@@ -37,6 +37,12 @@ class Preprocess(Command):
 
         header = 'Arduino.h' if self.e.arduino_lib_version.major else 'WProgram.h'
         out.write('#include <%s>\n' % header)
+
+        lines = sketch.splitlines()
+        for line in lines:
+            if line.startswith("#include"):
+                out.write(line + '\n')
+                
         out.write('\n'.join(self.prototypes(sketch)))
         out.write('\n#line 1 "%s"\n' % args.sketch)
         out.write(sketch)


### PR DESCRIPTION
Solves issues https://github.com/amperka/ino/issues/107 and https://github.com/amperka/ino/issues/74

Made it so that the preprocess adds all include statements found in the sketch to the beginning of the file, before any prototypes. This fixes problems with "xxx was not declared in this scope" when using enums, structs or typedefs in the function prototypes.

These are the first lines of python I ever write so please be gentle in the comments..

I messed up the first pull request and made it to a fork of https://github.com/amperka/ino - hopefully I got it right this time :)
