### PR TITLE
Call Python 2 explicitely (temporary fix for #106)

### DIFF
--- a/bin/ino
+++ b/bin/ino
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from ino.runner import main
 


### PR DESCRIPTION
As noted by @fengshaun in #106, some distribs are now setting Python 3 as default interpreter. Ino being Python 2 only for now, it should call Python 2 explicitly. While it doesn't address completely the #106 topic, this simple PR addresses the issue, making ino compatible with python-3-as-default distribs again.
