### PR TITLE
Arduino IDE 1.5 support (supports Due/AVR)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,12 +18,6 @@ build process to 3-rd party IDE.
 Ino is based on ``make`` to perform builds. However Makefiles are
 generated automatically and you'll never see them if you don't want to.
 
-Fork Notes
-==========
-
-Trying to fix up ino so that it works with Arduino 1.5.x. I plan
-on breaking backwards compatibility with 1.0 with these changes.
-
 Features
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,10 @@
+Fork Notes
+==========
+
+Trying to fix up ino so that it works with Arduino 1.5.x. I plan
+on breaking backwards compatibility with 1.0 with these changes.
+
+
 ===
 Ino
 ===

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,3 @@
-Fork Notes
-==========
-
-Trying to fix up ino so that it works with Arduino 1.5.x. I plan
-on breaking backwards compatibility with 1.0 with these changes.
-
-
 ===
 Ino
 ===
@@ -24,6 +17,12 @@ build process to 3-rd party IDE.
 
 Ino is based on ``make`` to perform builds. However Makefiles are
 generated automatically and you'll never see them if you don't want to.
+
+Fork Notes
+==========
+
+Trying to fix up ino so that it works with Arduino 1.5.x. I plan
+on breaking backwards compatibility with 1.0 with these changes.
 
 Features
 ========

--- a/bin/ino
+++ b/bin/ino
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from ino.runner import main
 

--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -41,15 +41,11 @@ class Build(Command):
     help_line = "Build firmware from the current directory project"
 
     default_make = 'make'
-    default_cc = 'avr-gcc'
-    default_cxx = 'avr-g++'
-    default_ar = 'avr-ar'
-    default_objcopy = 'avr-objcopy'
 
-    default_cppflags = '-ffunction-sections -fdata-sections -g -Os -w'
+    default_cppflags = ''
     default_cflags = ''
-    default_cxxflags = '-fno-exceptions'
-    default_ldflags = '-Os --gc-sections'
+    default_cxxflags = ''
+    default_ldflags = ''
 
     def setup_arg_parser(self, parser):
         super(Build, self).setup_arg_parser(parser)
@@ -60,31 +56,34 @@ class Build(Command):
                             default=self.default_make,
                             help='Specifies the make tool to use. If '
                             'a full path is not given, searches in Arduino '
-                            'directories before PATH. Default: "%(default)s".')
+                            'directories before PATH. Default: %(default)s".')
 
         parser.add_argument('--cc', metavar='COMPILER',
-                            default=self.default_cc,
+                            default=None,
                             help='Specifies the compiler used for C files. If '
                             'a full path is not given, searches in Arduino '
-                            'directories before PATH. Default: "%(default)s".')
+                            'directories before PATH for the architecture '
+                            'specific compiler.')
 
         parser.add_argument('--cxx', metavar='COMPILER',
-                            default=self.default_cxx,
+                            default=None,
                             help='Specifies the compiler used for C++ files. '
                             'If a full path is not given, searches in Arduino '
-                            'directories before PATH. Default: "%(default)s".')
+                            'directories before PATH for the architecture '
+                            'specific compiler.')
 
         parser.add_argument('--ar', metavar='AR',
-                            default=self.default_ar,
+                            default=None,
                             help='Specifies the AR tool to use. If a full path '
                             'is not given, searches in Arduino directories '
-                            'before PATH. Default: "%(default)s".')
+                            'before PATH for the architecture specific ar tool.')
 
         parser.add_argument('--objcopy', metavar='OBJCOPY',
-                            default=self.default_objcopy,
+                            default=None,
                             help='Specifies the OBJCOPY to use. If a full path '
                             'is not given, searches in Arduino directories '
-                            'before PATH. Default: "%(default)s".')
+                            'before PATH for the architecture specific objcopy '
+                            'tool.')
 
         parser.add_argument('-f', '--cppflags', metavar='FLAGS',
                             default=self.default_cppflags,
@@ -118,49 +117,115 @@ class Build(Command):
                             help='Verbose make output')
 
     def discover(self, args):
+        board = self.e.board_model(args.board_model)
+
         self.e.find_arduino_dir('arduino_core_dir', 
-                                ['hardware', 'arduino', 'cores', 'arduino'], 
+                                ['hardware', 'arduino', board['arch'], 'cores', 'arduino'], 
                                 ['Arduino.h'] if self.e.arduino_lib_version.major else ['WProgram.h'], 
-                                'Arduino core library')
+                                'Arduino core library ({})'.format(board['arch']))
 
         self.e.find_arduino_dir('arduino_libraries_dir', ['libraries'],
                                 human_name='Arduino standard libraries')
 
+        if board['arch'] in ['sam']:
+            self.e.find_arduino_dir('arduino_system_dir', ['hardware', 'arduino', board['arch'], 'system'],
+                                    human_name='Arduino system libraries')
+
         if self.e.arduino_lib_version.major:
             self.e.find_arduino_dir('arduino_variants_dir',
-                                    ['hardware', 'arduino', 'variants'],
-                                    human_name='Arduino variants directory')
+                                    ['hardware', 'arduino', board['arch'], 'variants'],
+                                    human_name='Arduino variants directory ({})'.format(board['arch']))
 
         toolset = [
-            ('make', args.make),
-            ('cc', args.cc),
-            ('cxx', args.cxx),
-            ('ar', args.ar),
-            ('objcopy', args.objcopy),
+            ('make', args.make, 'avr'),
+            ('cc', args.cc, None),
+            ('cxx', args.cxx, None),
+            ('ar', args.ar, None),
+            ('ld', None, None),
+            ('objcopy', args.objcopy, None),
         ]
 
-        for tool_key, tool_binary in toolset:
+        tools_arch_mapping = {
+            'avr': {
+                'dirname': 'avr',
+                'tool_prefix': 'avr-',
+                'tools': {
+                    'make': 'make',
+                    'cc': 'gcc',
+                    'cxx': 'g++',
+                    'ar': 'ar',
+                    'ld': 'gcc',
+                    'objcopy': 'objcopy'
+                }
+            },
+            'sam': {
+                'dirname': 'g++_arm_none_eabi',
+                'tool_prefix': 'arm-none-eabi-',
+                'tools': {
+                    'cc': 'gcc',
+                    'cxx': 'g++',
+                    'ar': 'ar',
+                    'ld': 'g++',
+                    'objcopy': 'objcopy'
+                }
+            }
+        }
+
+        if board['arch'] not in tools_arch_mapping:
+            raise Abort('Unknown architecture "{}"'.format(board['arch']))
+
+        arch_info = tools_arch_mapping[board['arch']]
+
+        for tool_key, tool_binary, arch_override in toolset:
+            actual_tool_binary = tool_binary if tool_binary else arch_info['tool_prefix'] + arch_info['tools'][tool_key]
+            
             self.e.find_arduino_tool(
-                tool_key, ['hardware', 'tools', 'avr', 'bin'], 
-                items=[tool_binary], human_name=tool_binary)
+                tool_key, ['hardware', 'tools', arch_info['dirname'] if not arch_override else arch_override, 'bin'], 
+                items=[actual_tool_binary], human_name=tool_binary)
 
     def setup_flags(self, args):
         board = self.e.board_model(args.board_model)
-        mcu = '-mmcu=' + board['build']['mcu']
+
+        mcu_key = '-mcpu=' if board['arch'] in ['sam'] else '-mmcu='
+        mcu = mcu_key + board['build']['mcu']
+
         # Hard-code the flags that are essential to building the sketch
         self.e['cppflags'] = SpaceList([
             mcu,
             '-DF_CPU=' + board['build']['f_cpu'],
             '-DARDUINO=' + str(self.e.arduino_lib_version.as_int()),
+            '-DARDUINO_' + board['build']['board'],
+            '-DARDUINO_ARCH_' + board['arch'].upper(),
             '-I' + self.e['arduino_core_dir'],
         ]) 
+
         # Add additional flags as specified
         self.e['cppflags'] += SpaceList(shlex.split(args.cppflags))
+
+        platform_settings = self.e.platform_settings()[board['arch']]
+        self.e['cppflags'] += SpaceList(platform_settings['compiler']['cpp']['flags'].split(' '))
+
+        self.e['objcopyflags'] = SpaceList(platform_settings['compiler']['elf2hex']['flags'].split(' '))
+
+        # SAM boards have a pre-built system library
+        if board['arch'] in ['sam']:
+            system_dir = self.e.arduino_system_dir
+            self.e['cppflags'] += [p.replace("{build.system.path}", system_dir) for p in
+                ["-I{build.system.path}/libsam", 
+                 "-I{build.system.path}/CMSIS/CMSIS/Include/", 
+                 "-I{build.system.path}/CMSIS/Device/ATMEL/"]]
 
         if 'vid' in board['build']:
             self.e['cppflags'].append('-DUSB_VID=%s' % board['build']['vid'])
         if 'pid' in board['build']:
             self.e['cppflags'].append('-DUSB_PID=%s' % board['build']['pid'])
+        if board['arch'] in ['sam']:
+            self.e['cppflags'].append('-DUSBCON')
+        
+        if 'extra_flags' in board['build']:
+            flags = [f.strip() for f in board['build']['extra_flags'].split(' ')]
+            flags = filter(lambda f: f not in ['{build.usb_flags}'], flags)
+            self.e['cppflags'].extend(flags)
             
         if self.e.arduino_lib_version.major:
             variant_dir = os.path.join(self.e.arduino_variants_dir, 
@@ -168,6 +233,7 @@ class Build(Command):
             self.e.cppflags.append('-I' + variant_dir)
 
         self.e['cflags'] = SpaceList(shlex.split(args.cflags))
+
         self.e['cxxflags'] = SpaceList(shlex.split(args.cxxflags))
 
         # Again, hard-code the flags that are essential to building the sketch
@@ -175,6 +241,49 @@ class Build(Command):
         self.e['ldflags'] += SpaceList([
             '-Wl,' + flag for flag in shlex.split(args.ldflags)
         ])
+
+        self.e['ld_pre'] = ''
+        self.e['ld_post'] = ''
+
+        if board['arch'] in ['sam']:
+            self.e['ldflags'] += SpaceList(['-mthumb', '-lgcc'])
+            self.e['ld_pre'] = SpaceList([
+                '-Wl,--check-sections',
+                '-Wl,--gc-sections',
+                '-Wl,--entry=Reset_Handler',
+                '-Wl,--unresolved-symbols=report-all',
+                '-Wl,--warn-common',
+                '-Wl,--warn-section-align',
+                '-Wl,--warn-unresolved-symbols',
+                '-Wl,--start-group'
+            ])
+
+            # The order of linking is very specific in the SAM build.
+            # This .o must come first, then the variant system lib,
+            # then the project object files.
+            self.e['ld_pre'] += SpaceList([
+                os.path.join(self.e.build_dir, 'arduino', 'syscalls_sam3.o')
+            ])
+
+            self.e['ld_post'] = SpaceList([
+                '-Wl,--end-group'
+            ])
+        
+        if 'variant_system_lib' in board['build']:
+            variant_system_lib = os.path.join(self.e.arduino_variants_dir, 
+                                              board['build']['variant'],
+                                              board['build']['variant_system_lib'])
+            self.e['ld_variant_system_lib'] = variant_system_lib
+        else:
+            self.e['ld_variant_system_lib'] = ''
+
+        if 'ldscript' in board['build']:
+            ldscript = os.path.join(self.e.arduino_variants_dir, 
+                                    board['build']['variant'],
+                                    board['build']['ldscript'])
+            self.e['ldflags'] += SpaceList([
+                '-T' + ldscript
+            ])
 
         self.e['names'] = {
             'obj': '%s.o',
@@ -215,11 +324,34 @@ class Build(Command):
         if ret != 0:
             raise Abort("Make failed with code %s" % ret)
 
-    def recursive_inc_lib_flags(self, libdirs):
+    def recursive_inc_lib_flags(self, libdirs, board_arch):
+        # These directories are not used in a build. For more info see
+        # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification
+        ignore_architectures = set(board['arch'] for board in self.e.board_models().itervalues()) - set([board_arch])
+        lib_excludes = ['extras', 'examples']
+        
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+
+            for subdir in list_subdirs(d, exclude=lib_excludes):
+                # This dir requires special handling as it is architecture specific.
+                # It is explained in more detail in the link above, but the expected
+                # behavior is to prefer a subdir that matches the board architecture,
+                # or if none is found, use the 'default' unoptimized architecture.
+                if os.path.basename(subdir) == 'arch':
+                    arch_subdir = list_subdirs(subdir, include=[board_arch])
+
+                    if not arch_subdir:
+                        arch_subdir = list_subdirs(subdir, include=['default'])
+
+                    if arch_subdir:
+                        flags.append('-I' + arch_subdir[0])
+                        flags.extend('-I' + subd for subd in list_subdirs(arch_subdir[0], recursive=True, exclude=lib_excludes))
+                else:
+                    flags.append('-I' + subdir)
+                    flags.extend('-I' + subd for subd in list_subdirs(subdir, recursive=True, exclude=lib_excludes))
+
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):
@@ -241,11 +373,18 @@ class Build(Command):
 
         return used_libs
 
-    def scan_dependencies(self):
+    def scan_dependencies(self, args):
+        board = self.e.board_model(args.board_model)
+        board_arch = board['arch']
+
         self.e['deps'] = SpaceList()
 
-        lib_dirs = [self.e.arduino_core_dir] + list_subdirs(self.e.lib_dir) + list_subdirs(self.e.arduino_libraries_dir)
-        inc_flags = self.recursive_inc_lib_flags(lib_dirs)
+        lib_dirs = [self.e.arduino_core_dir]
+        lib_dirs += list_subdirs(self.e.lib_dir) 
+        lib_dirs += list_subdirs(self.e.arduino_libraries_dir)
+        lib_dirs += [os.path.join(self.e.arduino_variants_dir, board['build']['variant'])]
+
+        inc_flags = self.recursive_inc_lib_flags(lib_dirs, board_arch)
 
         # If lib A depends on lib B it have to appear before B in final
         # list so that linker could link all together correctly
@@ -275,12 +414,12 @@ class Build(Command):
                 scanned_libs.add(lib)
 
         self.e['used_libs'] = used_libs
-        self.e['cppflags'].extend(self.recursive_inc_lib_flags(used_libs))
+        self.e['cppflags'].extend(self.recursive_inc_lib_flags(used_libs, board_arch))
 
     def run(self, args):
         self.discover(args)
         self.setup_flags(args)
         self.create_jinja(verbose=args.verbose)
         self.make('Makefile.sketch')
-        self.scan_dependencies()
+        self.scan_dependencies(args)
         self.make('Makefile')

--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -92,7 +92,6 @@ class Upload(Command):
         # this, for some devices wait a moment for the bootloader to enumerate. 
         # On Windows, also must deal with the fact that the COM port number 
         # changes from bootloader to sketch.
-        import ino.debugger;ino.debugger.set_trace()
         if 'use_1200bps_touch' in board['upload'] and board['upload']['use_1200bps_touch'] == 'true':
             before = self.e.list_serial_ports()
             if port in before:

--- a/ino/debugger.py
+++ b/ino/debugger.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 try:
     import ipdb
@@ -14,4 +15,27 @@ except ImportError,e:
 
     def pm(t):
         pdb.post_mortem(t)
+
+__PASSTHROUGH_EXCEPTIONS = (SyntaxError, SystemExit, KeyboardInterrupt)
+
+def should_use_debugger():
+    is_interactive_terminal = sys.stdout.isatty() and sys.stdin.isatty() and sys.stderr.isatty()
+    ino_debugger = "INO_DEBUGGER" in os.environ
+    return is_interactive_terminal and ino_debugger
+
+def auto_debug_break(type, value, tb):
+    import traceback
+
+    if type in __PASSTHROUGH_EXCEPTIONS:
+        traceback.print_exception(type, value, tb)
+        sys.exit(1)
+
+    if not should_use_debugger():
+        sys.__excepthook__(type, value, tb)
+        return
+
+    traceback.print_exception(type, value, tb)
+
+    pm(tb)
+
 

--- a/ino/debugger.py
+++ b/ino/debugger.py
@@ -1,0 +1,17 @@
+import sys
+
+try:
+    import ipdb
+    def set_trace():
+        ipdb.set_trace()
+    def pm(t):
+        ipdb.post_mortem(t)
+
+except ImportError,e:
+    import pdb
+    def set_trace():
+        pdb.Pdb(skip=['ino.ipdb']).set_trace()
+
+    def pm(t):
+        pdb.post_mortem(t)
+

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -198,20 +198,18 @@ class Environment(dict):
 
             # Populate the architecture so we know for future reference where to look
             if multikey[0] not in subdict:
-                subdict[multikey[0]] = {}
+                subdict[multikey[0]] = SettingsDict()
                 for k,v in data_on_root:
                     subdict[multikey[0]][k] = v
 
             for key in multikey[:-1]:
-                # 1.5.x for some dumb reason added keys like:
-                #       atmega328diecimila.menu.cpu.atmega328=ATmega328
-                #       atmega328diecimila.menu.cpu.atmega328.upload.maximum_size=30720
-                #
-                # It's hacky, but here we force a dict type if we encounter a nested key
-                # that already has a non-dict value. In practice they only seem to have
-                # done this with menu names.
-                if key not in subdict or not isinstance(subdict[key], dict):
-                    subdict[key] = {}
+                if key not in subdict:
+                    subdict[key] = SettingsDict()
+                elif not isinstance(subdict[key], dict):
+                    d = SettingsDict()
+                    d.value = subdict[key]
+                    subdict[key] = d
+
                 subdict = subdict[key]
 
             subdict[multikey[-1]] = val
@@ -338,6 +336,13 @@ class Environment(dict):
 
         return self['arduino_lib_version']
 
+class SettingsDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(SettingsDict, self).__init__(*args, **kwargs)
+        self.value = ''
+
+    def __str__(self):
+        return self.value 
 
 class BoardModels(OrderedDict):
     def format(self):

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -210,6 +210,12 @@ class Environment(dict):
                     multikey = multikey.split('.')
 
                     subdict = self['board_models']
+
+                    # Populate the architecture so we know for future reference where to look
+                    if multikey[0] not in subdict:
+                        subdict[multikey[0]] = {}
+                        subdict[multikey[0]]["arch"] = architecture
+
                     for key in multikey[:-1]:
                         # 1.5.x for some dumb reason added keys like:
                         #       atmega328diecimila.menu.cpu.atmega328=ATmega328

--- a/ino/make/Makefile.deps.jinja
+++ b/ino/make/Makefile.deps.jinja
@@ -16,7 +16,7 @@
 {% for source, target in cpp.items() %}
 {{ target.path }} : {{ source.path }}
 	@mkdir -p {{ target.path|dirname }}
-	{{v}}{{ e.cc }} {{ e.cppflags }} {{ inc_flags }} {{ iquote(source) }} -MM $^ > $@
+	{{v}}{{ e.cc }} {{ e.cppflags }} {{ inc_flags }} {{ iquote(source) }} -MM $^ -MF $@
 	{# prepend build path to a target in the generated file and 
 	   add .d file itself as a target so that changes in a header file would rebuild dependency files
 	   See: http://make.paulandlesley.org/autodep.html #}

--- a/ino/make/Makefile.jinja
+++ b/ino/make/Makefile.jinja
@@ -56,14 +56,14 @@ include {{ target.path|depsname }}
 {% set elf = e.build_dir|pjoin('firmware.elf') %}
 {{ elf }} : {{ objs }}
 	@echo {{ 'Linking firmware.elf'|colorize('green') }}
-	{{v}}{{ e.cc }} {{ e.ldflags }} -o $@ $^ -lm
+	{{v}}{{ e.ld }} {{ e.ldflags }} -o $@ -lm {{ e.ld_pre }} {{ e.ld_variant_system_lib }} $^ {{ e.ld_post }}
 
 {#
  #   elf -> hex
  #}
 {{ e.hex_path }} : {{ elf }}
 	@echo {{ ('Converting to ' ~ e.hex_filename)|colorize('green') }}
-	{{v}}{{ e.objcopy }} -O ihex -R .eeprom $^ $@
+	{{v}}{{ e.objcopy }} {{ e.objcopyflags }} $^ $@
 
 include {{ e.deps }}
 

--- a/ino/runner.py
+++ b/ino/runner.py
@@ -29,28 +29,7 @@ from ino.exc import Abort
 from ino.filters import colorize
 from ino.environment import Environment
 from ino.argparsing import FlexiFormatter
-
-__PASSTHROUGH_EXCEPTIONS = (SyntaxError, SystemExit, KeyboardInterrupt)
-
-def should_use_debugger():
-    is_interactive_terminal = sys.stdout.isatty() and sys.stdin.isatty() and sys.stderr.isatty()
-    ino_debugger = "INO_DEBUGGER" in os.environ
-    return is_interactive_terminal and ino_debugger
-
-def auto_debug_break(type, value, tb):
-    import traceback, ino.debugger
-
-    if type in __PASSTHROUGH_EXCEPTIONS:
-        traceback.print_exception(type, value, tb)
-        sys.exit(1)
-
-    if not should_use_debugger():
-        sys.__excepthook__(type, value, tb)
-        return
-
-    traceback.print_exception(type, value, tb)
-
-    ino.debugger.pm(tb)
+from ino.debugger import auto_debug_break, should_use_debugger
 
 def main():
     sys.excepthook = auto_debug_break
@@ -99,7 +78,7 @@ def main():
 
         args.func(args)
     except Abort as exc:
-        if should_use_debugger(exc):
+        if should_use_debugger():
             raise
         else:
             print colorize(str(exc), 'red')

--- a/ino/utils.py
+++ b/ino/utils.py
@@ -36,9 +36,9 @@ class FileMap(OrderedDict):
     def target_paths(self):
         return SpaceList(x.path for x in self.targets())
 
-
-def list_subdirs(dirname, recursive=False, exclude=[]):
-    entries = [e for e in os.listdir(dirname) if e not in exclude and not e.startswith('.')]
+def list_subdirs(dirname, recursive=False, exclude=[], include=None):
+    entries = [e for e in os.listdir(dirname) 
+               if e not in exclude and (not include or e in include) and not e.startswith('.') and not e.startswith('_')]
     paths = [os.path.join(dirname, e) for e in entries]
     dirs = filter(os.path.isdir, paths)
     if recursive:


### PR DESCRIPTION
They pretty much broke everything that ino relied upon, so there are a lot of changes that were necessary to get this tool working again with their new SDK layout. Here is the short list of things that had to be fixed:
- Support for handling the multiple architecture directories when discovering boards.
- Support for handling the new Arduino library layout that can have architecture specific code.
- Completely different toolchain and compile options necessary when building different architectures.
  - Many compile options are no longer hard-coded in ino, they are read from the architecture's platform.txt.
- Uploader uses the correct tool for each architecture.
- Uploader now references boards.txt information for how to handle the 1200bps 'touch' and also the upload wait.

I've successfully tested these changes on an Arduino Uno R3 (AVR), and a Due (SAM). 

However, these fixes do break support for the 1.0 IDE. If that is a concern perhaps it's worth holding off on this pull request until 1.5 is out of beta and you are willing to discontinue supporting 1.0 officially.
