### PR TITLE
Added support for .S files when building firmware

### DIFF
--- a/ino/make/Makefile.jinja
+++ b/ino/make/Makefile.jinja
@@ -38,9 +38,11 @@ include {{ target.path|depsname }}
 {% for source_dir, target in libs.items() %}
 {% set c = source_dir|glob('*.c')|filemap(target.dirname, e.names.obj) %}
 {% set cpp = (source_dir|glob('*.cpp'))|filemap(target.dirname, e.names.obj) %}
-{% set libobjs = c.target_paths() + cpp.target_paths() %}
+{% set S = (source_dir|glob('*.S'))|filemap(target.dirname, e.names.obj) %}
+{% set libobjs = c.target_paths() + cpp.target_paths() + S.target_paths() %}
 {{ compile_c(c) }}
 {{ compile_cpp(cpp) }}
+{{ compile_S(S) }}
 {{ target.path }} : {{ libobjs }}
 	@echo {{ ('Linking ' ~ target.filename|basename)|colorize('green') }}
 	{{v}}{{ e.ar }} rcs $@ $^

--- a/ino/make/Makefile.jinja
+++ b/ino/make/Makefile.jinja
@@ -22,6 +22,15 @@ include {{ target.path|depsname }}
 {{ compile(filemap, e.cxx ~ ' ' ~ e.cppflags ~ ' ' ~ e.cxxflags) }}
 {% endmacro %}
 
+{% macro compile_S(filemap) %}
+{% for source, target in filemap.items() %}
+{{ target.path }} : {{ source.path }}
+	@echo {{ (source.dirname|basename|pjoin(source.filename))|colorize('yellow') }}
+	@mkdir -p {{ target.path|dirname }}
+	{{v}}{{ e.cc ~ ' ' ~ e.cppflags ~ ' ' ~ e.cflags }} {{ iquote(source) }} -o $@ -c {{ source.path }}
+{% endfor %}
+{% endmacro %}
+
 {#
  #   library sources -> *.a
  #}
@@ -50,9 +59,15 @@ include {{ target.path|depsname }}
 {{ compile_cpp(cpp) }}
 
 {#
+ #   *.S -> *.o
+ #}
+{% set S = (e.src_dir|glob('*.S') + src_build_dir|glob('*.S'))|filemap(src_build_dir, e.names.obj) %}
+{{ compile_S(S) }}
+
+{#
  #   *.o -> elf
  #}
-{% set objs = c.target_paths() + cpp.target_paths() + libs.target_paths() %}
+{% set objs = c.target_paths() + cpp.target_paths() + libs.target_paths() + S.target_paths() %}
 {% set elf = e.build_dir|pjoin('firmware.elf') %}
 {{ elf }} : {{ objs }}
 	@echo {{ 'Linking firmware.elf'|colorize('green') }}


### PR DESCRIPTION
I wanted to use some AVR assembly sources in an Arduino sketch, and was surprised to see Ino doesn't handle .S files by default.
I think it's a low-impact change and it does what it should, so I was hoping you would consider merging this feature upstream.
