### PR TITLE
Fallback to /etc while searching for avrdude.conf

### DIFF
--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -41,7 +41,8 @@ class Upload(Command):
             self.e.find_arduino_tool('avrdude', ['hardware', 'tools'])
 
             conf_places = self.e.arduino_dist_places(['hardware', 'tools'])
-            conf_places.append('/etc/avrdude') # fallback to system-wide conf on Fedora
+            conf_places.append('/etc/avrdude') # fallback to system-wide conf on Fedora...
+            conf_places.append('/etc')         # ...and on Arch Linux
             self.e.find_file('avrdude.conf', places=conf_places)
         else:
             self.e.find_arduino_tool('avrdude', ['hardware', 'tools', 'avr', 'bin'])


### PR DESCRIPTION
Arch Linux stores it's system-wide avrdude.conf straight in /etc so this patch will allow compatibility with such a setup.

I'm not familiar with this codebase and I've only tested this on my own machine, but hopefully this change is low-impact enough to be harmless enough and still help out the Arch Linux guys!
