### PR TITLE
Add support for Arduino 1.5.4

### DIFF
--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -119,7 +119,8 @@ class Build(Command):
 
     def discover(self, args):
         self.e.find_arduino_dir('arduino_core_dir', 
-                                ['hardware', 'arduino', 'cores', 'arduino'], 
+                                [['hardware', 'arduino', 'cores', 'arduino'], 
+                                 ['hardware', 'arduino', 'avr', 'cores', 'arduino']],
                                 ['Arduino.h'] if self.e.arduino_lib_version.major else ['WProgram.h'], 
                                 'Arduino core library')
 
@@ -128,7 +129,8 @@ class Build(Command):
 
         if self.e.arduino_lib_version.major:
             self.e.find_arduino_dir('arduino_variants_dir',
-                                    ['hardware', 'arduino', 'variants'],
+                                    [['hardware', 'arduino', 'variants'], 
+                                     ['hardware', 'arduino', 'avr', 'variants']],
                                     human_name='Arduino variants directory')
 
         toolset = [
@@ -219,7 +221,7 @@ class Build(Command):
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples', "extras"]))
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):

--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -135,6 +135,20 @@ class Upload(Command):
 
             port = caterina_port
 
+            # udev might need some time to change the owner and/or chmod
+            accessible = False
+            elapsed = 0
+            while elapsed < 2:
+                accessible = os.access(port, os.R_OK|os.W_OK)
+                if accessible:
+                    break
+
+                sleep(enum_delay)
+                elapsed += enum_delay
+
+            if not accessible:
+                print("WARNING: The device file '%s' is probably not accessible, but I will try anyway.")
+
         if verbose:
             avrdude_verbose = ["-v", "-v", "-v", "-v"]
         else:

--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -83,7 +83,8 @@ class Upload(Command):
         # this wait a moment for the bootloader to enumerate. On Windows, also must
         # deal with the fact that the COM port number changes from bootloader to
         # sketch.
-        if board['bootloader']['path'] == "caterina":
+        if 'path' in board['bootloader'] and board['bootloader']['path'] == "caterina" or \
+                'use_1200bps_touch' in board['upload'] and board['upload']['use_1200bps_touch'] == "true":
             caterina_port = None
             before = self.e.list_serial_ports()
             if port in before:

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -312,5 +312,5 @@ class Environment(dict):
 
 class BoardModels(OrderedDict):
     def format(self):
-        map = [(key, val['name']) for key, val in self.iteritems()]
+        map = [(key, val['name']) for key, val in self.iteritems() if 'name' in val]
         return format_available_options(map, head_width=12, default=self.default)


### PR DESCRIPTION
Newer versions of the Arduino libraries introduce support for other processor families and the paths we are interested in contain an additional 'avr'. This PR makes ino work old-style and new-style paths and has some more changes to make it work with new-style board.txt files. I have tested it with Arduino 1.5.4 with Leonard, Yun and Pro Micro boards.

In addition, it has two more changes that are not related to Arduino 1.5. I can make three seperate pull requests, if you prefer that.
- add verbose flag for upload
- wait until device file is accessible (i.e. ino won't call avrdude before udev has changed device permissions)
