### PR TITLE
Automated sketchbook libraries detection

### DIFF
--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -133,6 +133,9 @@ class Build(Command):
         self.e.find_arduino_dir('arduino_libraries_dir', ['libraries'],
                                 human_name='Arduino standard libraries')
 
+        self.e.find_sketchbook_dir('sketchbook_lib_dir', ['libraries'],
+                                   human_name='Arduino sketchbook libraries')
+
         toolset = [
             ('make', args.make),
             ('cc', args.cc),
@@ -247,6 +250,10 @@ class Build(Command):
         self.e['deps'] = SpaceList()
 
         lib_dirs = [self.e.arduino_core_dir] + list_subdirs(self.e.lib_dir) + list_subdirs(self.e.arduino_libraries_dir)
+
+        if self.e.sketchbook_lib_dir is not None:
+            lib_dirs += list_subdirs(self.e.sketchbook_lib_dir)
+
         inc_flags = self.recursive_inc_lib_flags(lib_dirs)
 
         # If lib A depends on lib B it have to appear before B in final


### PR DESCRIPTION
As I stumbled in #50, I started using @mchughj solution ( mchughj@e55df22 ), for I needed a way to seamlessly use the libraries I had already in my sketchbook dir. I thought that, given the beauty of the autodetection principle of ino, I could add a fully-fledged and transparent sketchbook libraries detection. This solution works fine under OSX and linux, tested with Arduino ide 1.0.
