### PR TITLE
patch to allow for avrdude to erase by not appending -D

### DIFF
--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -53,7 +53,6 @@ class Upload(Command):
     def run(self, args):
         self.discover()
         port = args.serial_port or self.e.guess_serial_port()
-        erase = args.auto_erase
         board = self.e.board_model(args.board_model)
 
         protocol = board['upload']['protocol']
@@ -138,7 +137,7 @@ class Upload(Command):
             '-c', protocol,
             '-b', board['upload']['speed'],
             '-U', 'flash:w:%s:i' % self.e['hex_path']
-            ]
+        ]
         if (args.auto_erase == '0'):
             avrargs.append('-D')
         subprocess.call(avrargs)

--- a/ino/commands/upload.py
+++ b/ino/commands/upload.py
@@ -138,6 +138,8 @@ class Upload(Command):
             '-b', board['upload']['speed'],
             '-U', 'flash:w:%s:i' % self.e['hex_path']
         ]
+
         if (args.auto_erase == '0'):
             avrargs.append('-D')
+
         subprocess.call(avrargs)


### PR DESCRIPTION
Certain devices (such as the gertduino board) will fail verification if you don't first erase.  At present, -D is passed to avrdude, which suppresses this erase.  I have created a small patch to allow passing --auto-erase 1 to tell it to erase.  Otherwise, it will maintain the existing default behavior.  I would have preferred doing a --auto-erase with no argument, but icouldn't think of a clean way to implement that into an ini file while keeping the command line as argument-less.
