### PR TITLE
Boards.txt can reside within ~/Documents/Arduino on Mac

### DIFF
--- a/ino/environment.py
+++ b/ino/environment.py
@@ -80,6 +80,7 @@ class Environment(dict):
 
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
+        arduino_dist_dir_guesses.insert(0, os.path.expanduser('~/Documents/Arduino'))
 
     default_board_model = 'uno'
     ino = sys.argv[0]


### PR DESCRIPTION
Fix for issue #212
