### PR TITLE
Ignore `src` directories when traversing libraries

### DIFF
--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -221,7 +221,7 @@ class Build(Command):
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples','src']))
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):


### PR DESCRIPTION
This PR is a fix for the issue with Arduino 1.5.8 installs causing problems with builds: `make: execvp: /bin/sh: Argument list too long`, seen in #111, #119, #121, and #168.

Somehow, `src` directories are being added to the Resources/Java/libraries path in the Arduino.app distribution. For example (two lines out of thousands): 

```
/Applications/Arduino.app/Contents/Resources/Java/libraries/WiFi/extras/wifiHD/src/SOFTWARE_FRAMEWORK/SERVICES/LWIP/lwip-1.3.2/src/include/ipv4/lwip
/Applications/Arduino.app/Contents/Resources/Java/libraries/WiFi/extras/wifiHD/src/SOFTWARE_FRAMEWORK/SERVICES/LWIP/lwip-1.3.2/src/include/lwip
```

This generates a remarkably enormous Makefile, because of all the `-I <libpath>` arguments, none of which are needed, and of course it won't run properly either.

This PR fixes it by adding `src` to the excludes argument to `list_subdirs`.
