### PR TITLE
1.5.x: add an alternate Java directory path for OS X systems

### DIFF
--- a/ino/environment.py
+++ b/ino/environment.py
@@ -80,6 +80,7 @@ class Environment(dict):
 
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
+        arduino_dist_dir_guesses.insert(1, '/Applications/Arduino.app/Contents/Java')
 
     default_board_model = 'uno'
     ino = sys.argv[0]


### PR DESCRIPTION
Fixes this error with the 1.5.8 beta on OS X:

```
Searching for Board description file (boards.txt) ... FAILED
Board description file (boards.txt) not found. Searched in following places:
  - /Applications/Arduino.app/Contents/Resources/Java/hardware/**
  - /usr/local/share/arduino/hardware/**
  - /usr/share/arduino/hardware/**
```

In the meantime, you can fix the error with a symlink:

``` sh
cd /Applications/Arduino.app/Contents/Resources
ln -s ../Java .
```
