### PR TITLE
Updated search path for Arduino 1.6.3 on OS X.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/.build
 .*.sw[op]
 /.project
 /.settings
+/.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 ino.egg-info
 doc/.build
 .*.sw[op]
+/.project
+/.settings

--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -221,7 +221,8 @@ class Build(Command):
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+            # recursive=True creates so many include directories that it exceeds avg-gcc's maximum list length.
+            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=False, exclude=['examples']))
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -80,6 +80,7 @@ class Environment(dict):
 
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
+        arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Java') # Arduino 1.6.3 on OS X 10.10.*
 
     default_board_model = 'uno'
     ino = sys.argv[0]


### PR DESCRIPTION
The search path for the current Arduino 1.6.3 on OS X seems to have changed very slightly. Per issue #71, I added the search path the OS X users reported for their system.
