### PR TITLE
Excluding src and add reference for new OS X location

### DIFF
--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -221,7 +221,7 @@ class Build(Command):
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples','src']))
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):

--- a/ino/environment.py
+++ b/ino/environment.py
@@ -80,6 +80,7 @@ class Environment(dict):
 
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
+        arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Java')
 
     default_board_model = 'uno'
     ino = sys.argv[0]


### PR DESCRIPTION
Excluding src directories from build command and added a new
location reference for arduino 1.6.3 on OS X 10.10.
