### PR TITLE
fixing O(too_much) bug in recursive list_subdirs

### DIFF
--- a/ino/utils.py
+++ b/ino/utils.py
@@ -40,11 +40,13 @@ class FileMap(OrderedDict):
 def list_subdirs(dirname, recursive=False, exclude=[]):
     entries = [e for e in os.listdir(dirname) if e not in exclude and not e.startswith('.')]
     paths = [os.path.join(dirname, e) for e in entries]
-    dirs = filter(os.path.isdir, paths)
+    dirs = [p for p in paths if os.path.isdir(p)]
+
     if recursive:
-        sub = itertools.chain.from_iterable(
-            list_subdirs(d, recursive=True, exclude=exclude) for d in dirs)
-        dirs.extend(sub)
+        sub = [ list_subdirs(d, recursive=True, exclude=exclude) for d in dirs ]
+        for i in sub:
+            dirs.extend(i)
+
     return dirs
 
 


### PR DESCRIPTION
for some reason this function was scanning subdirectories more than once, resulting in a really sub-ottimal performance.

with this patch, i was able to reduce build of the project i'm working on from:
real    1m1.629s

to:
real    0m1.923s

on some occasion i was also able to fix an:
(ino-env)Minene:ino willy$ time ino build > /dev/null
make: /bin/sh: Argument list too long
make: **\* [.build/uno/src/iec_driver.d] Error 1

real    0m32.280s
user    0m16.205s
sys 0m13.660s

error.
