### PR TITLE
Bash completion

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,3 +12,6 @@ Examples:
 
     * make install DESTDIR=~/ino
     * make install PREFIX=/usr
+
+If you would like to use Bash completion for ino's subcommands and arguments,
+have a look at the instructions in `bash-completion/ino'.

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -1,4 +1,14 @@
 # bash completion for ino, a command line toolkit for Arduino
+#
+# Depending on your system, privileges and preferences you might want to
+# copy this file either
+#
+#  * to the standard /usr/share/bash-completion/completions directory to be
+#    sourced on demand
+#  * to the legacy /etc/bash_completion.d directory to be sourced
+#    automatically for every interactive shell
+#  * to wherever you please, or not copy at all, and source it yourself from
+#    your .bashrc
 
 _ino_complete_board_models()
 {

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -82,6 +82,11 @@ _ino()
 		case "$prev" in
 		--serial-port)
 			;;
+		--baud-rate)
+			COMPREPLY=( $( compgen -W "300 600 1200 2400 4800
+				9600 14400 19200 28800 38400 57600 115200
+				" -- "$cur" ) )
+			;;
 		*)
 			COMPREPLY=( $( compgen -W "--help --serial-port
 				--baud-rate" -- "$cur" ) )

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -9,6 +9,38 @@ _ino()
 	if [ $cword = 1 ]; then
 		COMPREPLY=( $( compgen -W "build clean init list-models
 			preproc serial upload --help" -- "$cur" ) )
+		return
 	fi
+
+	case "${words[1]}" in
+	build)
+		COMPREPLY=( $( compgen -W "--help --board-model
+			--arduino-dist --make --cc --cxx --ar --objcopy
+			--cppflags --cflags --cxxflags --ldflags
+			--verbose" -- "$cur" ) )
+		;;
+	clean)
+		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+		;;
+	init)
+		COMPREPLY=( $( compgen -W "--help --template" -- "$cur" ) )
+		;;
+	list-models)
+		COMPREPLY=( $( compgen -W "--help --arduino-dist" \
+			-- "$cur" ) )
+		;;
+	preproc)
+		COMPREPLY=( $( compgen -W "--help --arduino-dist
+			--output" -- "$cur" ) )
+		;;
+	serial)
+		COMPREPLY=( $( compgen -W "--help --serial-port
+			--baud-rate" -- "$cur" ) )
+		;;
+	upload)
+		COMPREPLY=( $( compgen -W "--help --serial-port
+			--board-model --arduino-dist" -- "$cur" ) )
+		;;
+	esac
 } &&
 complete -o bashdefault -o default -F _ino ino

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -1,0 +1,14 @@
+# bash completion for ino, a command line toolkit for Arduino
+
+_ino()
+{
+	local cur prev words cword
+
+	_init_completion -n : || return
+
+	if [ $cword = 1 ]; then
+		COMPREPLY=( $( compgen -W "build clean init list-models
+			preproc serial upload --help" -- "$cur" ) )
+	fi
+} &&
+complete -o bashdefault -o default -F _ino ino

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -1,5 +1,14 @@
 # bash completion for ino, a command line toolkit for Arduino
 
+_ino_complete_board_models()
+{
+	local board_models
+
+	board_models="$(ino list-models 2>/dev/null | sed -n -e 's/: .*//p')"
+
+	COMPREPLY=( $( compgen -W "$board_models" -- "$cur" ) )
+}
+
 _ino()
 {
 	local cur prev words cword
@@ -16,6 +25,9 @@ _ino()
 	build)
 		case "$prev" in
 		--arduino-dist|--make|--cc|--cxx|--ar|--objcopy)
+			;;
+		--board-model)
+			_ino_complete_board_models
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "--help --board-model
@@ -64,6 +76,9 @@ _ino()
 	upload)
 		case "$prev" in
 		--arduino-dist|--serial-port)
+			;;
+		--board-model)
+			_ino_complete_board_models
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "--help --serial-port

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -14,10 +14,16 @@ _ino()
 
 	case "${words[1]}" in
 	build)
-		COMPREPLY=( $( compgen -W "--help --board-model
-			--arduino-dist --make --cc --cxx --ar --objcopy
-			--cppflags --cflags --cxxflags --ldflags
-			--verbose" -- "$cur" ) )
+		case "$prev" in
+		--arduino-dist|--make|--cc|--cxx|--ar|--objcopy)
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "--help --board-model
+				--arduino-dist --make --cc --cxx --ar --objcopy
+				--cppflags --cflags --cxxflags --ldflags
+				--verbose" -- "$cur" ) )
+			;;
+		esac
 		;;
 	clean)
 		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
@@ -26,20 +32,44 @@ _ino()
 		COMPREPLY=( $( compgen -W "--help --template" -- "$cur" ) )
 		;;
 	list-models)
-		COMPREPLY=( $( compgen -W "--help --arduino-dist" \
-			-- "$cur" ) )
+		case "$prev" in
+		--arduino-dist)
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "--help --arduino-dist" \
+				-- "$cur" ) )
+			;;
+		esac
 		;;
 	preproc)
-		COMPREPLY=( $( compgen -W "--help --arduino-dist
-			--output" -- "$cur" ) )
+		case "$prev" in
+		--arduino-dist|--output)
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "--help --arduino-dist
+				--output" -- "$cur" ) )
+			;;
+		esac
 		;;
 	serial)
-		COMPREPLY=( $( compgen -W "--help --serial-port
-			--baud-rate" -- "$cur" ) )
+		case "$prev" in
+		--serial-port)
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "--help --serial-port
+				--baud-rate" -- "$cur" ) )
+			;;
+		esac
 		;;
 	upload)
-		COMPREPLY=( $( compgen -W "--help --serial-port
-			--board-model --arduino-dist" -- "$cur" ) )
+		case "$prev" in
+		--arduino-dist|--serial-port)
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "--help --serial-port
+				--board-model --arduino-dist" -- "$cur" ) )
+			;;
+		esac
 		;;
 	esac
 } &&

--- a/bash-completion/ino
+++ b/bash-completion/ino
@@ -2,9 +2,24 @@
 
 _ino_complete_board_models()
 {
-	local board_models
+	local c=$cword dist_path list board_models
 
-	board_models="$(ino list-models 2>/dev/null | sed -n -e 's/: .*//p')"
+	while [ $c -ge 2 ]; do
+		if [ "${words[c]}" = "--arduino-dist" ]; then
+			dist_path="${words[++c]}"
+			break
+		fi
+		((c--))
+	done
+
+	list="$(ino list-models ${dist_path:+--arduino-dist "$dist_path"} 2>/dev/null)"
+	if [ $? != 0 ]; then
+		# 'ino list-models' failed, probably because of bogus
+		# '--arduino-dist <path>' given on the command line.
+		# Don't offer anything for completion.
+		return
+	fi
+	board_models="$(echo "$list" | sed -n -e 's/: .*//p')"
 
 	COMPREPLY=( $( compgen -W "$board_models" -- "$cur" ) )
 }


### PR DESCRIPTION
To make typing `ino` commands more comfortable.

```
$ ino <TAB>
build        --help       list-models  serial
clean        init         preproc      upload
$ ino build --<TAB>
--ar            --cflags        --help          --verbose
--arduino-dist  --cppflags      --ldflags
--board-model   --cxx           --make
--cc            --cxxflags      --objcopy
$ ino build --board-model <TAB>
atmega168     esplora       LilyPadUSB    nano          robotControl
atmega328     ethernet      mega          nano328       robotMotor
atmega8       fio           mega2560      pro           uno
bt            leonardo      micro         pro328
bt328         lilypad       mini          pro5v
diecimila     lilypad328    mini328       pro5v328
```

No `make install` integration, because
- there is no good place to install. A reasonably recent bash-completion package looks for completions either in `/usr/share/bash-completion/completions/` or in `/etc/bash_completion.d/` directories, and both of them are outside of the default `/usr/local/` install prefix.
- I don't know how it would work out with Python tools like `pip`.

Hence the short note at the end of `INSTALL` and a few instructions in `bash-completion/ino`.
