### PR TITLE
.model file to define default model for project

### DIFF
--- a/ino/environment.py
+++ b/ino/environment.py
@@ -81,7 +81,11 @@ class Environment(dict):
     if platform.system() == 'Darwin':
         arduino_dist_dir_guesses.insert(0, '/Applications/Arduino.app/Contents/Resources/Java')
 
-    default_board_model = 'uno'
+    def get_default_board_model():
+        if os.path.exists(".model"):
+            return open(".model","r").readline().strip()
+        return 'uno'
+    default_board_model = get_default_board_model()
     ino = sys.argv[0]
 
     def dump(self):


### PR DESCRIPTION
The modification allows inserting a .model file in the root of the project to specify a different default board for each project.
Since not all projects can be compiled for every board.
If no file is provided, uno is choosen as default (as it is right now)